### PR TITLE
Add ADK evaluation set for Malware Triage runbook

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,46 @@
+# Malware Triage Runbook Evaluation
+
+This directory contains the evaluation set for the Malware Triage runbook.
+
+## Prerequisites
+
+To run the evaluation, you need:
+
+1.  The `google-adk` package installed with the `eval` extra:
+    ```bash
+    pip install "google-adk[eval]"
+    ```
+2.  The `uv` package installed.
+3.  Access to Google SecOps, Google Threat Intelligence, and Vertex AI.
+
+## Environment Setup
+
+The agent requires a `.env` file in `mcp-security/run-with-google-adk/google-mcp-security-agent/`.
+You can copy `mcp-security/run-with-google-adk/google-mcp-security-agent/sample.env` to `.env` and fill in the required values:
+
+```bash
+cp mcp-security/run-with-google-adk/google-mcp-security-agent/sample.env mcp-security/run-with-google-adk/google-mcp-security-agent/.env
+```
+
+Set the following variables in the `.env` file:
+- `GOOGLE_API_KEY`: Your Gemini/Vertex AI API key.
+- `CHRONICLE_PROJECT_ID`: Google Cloud Project ID for Chronicle.
+- `CHRONICLE_CUSTOMER_ID`: Chronicle Customer ID.
+- `CHRONICLE_REGION`: Chronicle Region.
+- `VT_APIKEY`: VirusTotal API Key.
+- `SOAR_URL`: SecOps SOAR URL.
+- `SOAR_APP_KEY`: SecOps SOAR App Key.
+- `GOOGLE_CLOUD_PROJECT`: Google Cloud Project ID.
+- `GOOGLE_CLOUD_LOCATION`: Google Cloud Location (e.g., `us-central1`).
+
+## Running the Evaluation
+
+To run the evaluation, use the `adk eval` command:
+
+```bash
+adk eval mcp-security/run-with-google-adk/google-mcp-security-agent evals/malware_triage_eval.evalset.json
+```
+
+This will execute the agent defined in `mcp-security/run-with-google-adk/google-mcp-security-agent` against the `malware_triage_eval.evalset.json` file.
+
+**Note:** The evaluation requires live access to the services defined in the runbook. Ensure your environment is configured correctly.

--- a/evals/malware_triage_eval.evalset.json
+++ b/evals/malware_triage_eval.evalset.json
@@ -1,0 +1,121 @@
+{
+  "eval_set_id": "malware_triage_eval_set",
+  "name": "Malware Triage Runbook Evaluation",
+  "description": "Evaluation set for the Malware Triage runbook.",
+  "eval_cases": [
+    {
+      "eval_id": "malware_triage_case_1",
+      "conversation": [
+        {
+          "invocation_id": "inv-1",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Run the malware triage runbook for file hash 8ab2cf and case ID 12345."
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Do you want to generate a markdown report file for this triage?"
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "name": "get_case_full_details",
+                "args": {
+                  "case_id": "12345"
+                }
+              },
+              {
+                "name": "get_file_report",
+                "args": {
+                  "hash": "8ab2cf"
+                }
+              },
+              {
+                "name": "get_file_behavior_summary",
+                "args": {
+                  "hash": "8ab2cf"
+                }
+              },
+              {
+                "name": "search_security_events",
+                "args": {
+                  "text": "target.file.sha256 = \"8ab2cf\" OR target.file.md5 = \"8ab2cf\" OR target.file.sha1 = \"8ab2cf\"",
+                  "hours_back": 72
+                }
+              },
+              {
+                "name": "search_security_events",
+                "args": {
+                  "text": "principal.process.file.sha256 = \"8ab2cf\"",
+                  "hours_back": 72
+                }
+              },
+              {
+                "name": "get_ip_address_report",
+                "args": {
+                  "ip_address": "1.2.3.4"
+                }
+              },
+              {
+                "name": "list_cases",
+                "args": {}
+              },
+              {
+                "name": "post_case_comment",
+                "args": {
+                  "case_id": "12345",
+                  "comment": "Malware Triage for Hash 8ab2cf: ..."
+                }
+              }
+            ],
+            "intermediate_responses": []
+          }
+        },
+        {
+          "invocation_id": "inv-2",
+          "user_content": {
+            "parts": [
+              {
+                "text": "Yes"
+              }
+            ],
+            "role": "user"
+          },
+          "final_response": {
+            "parts": [
+              {
+                "text": "Malware Triage complete for 8ab2cf. Findings documented in case 12345. Report Status: Generated."
+              }
+            ],
+            "role": "model"
+          },
+          "intermediate_data": {
+            "tool_uses": [
+              {
+                "name": "write_to_file",
+                "args": {
+                  "content": "Malware Triage Report...",
+                  "filepath": "malware_triage_8ab2cf.md"
+                }
+              }
+            ],
+            "intermediate_responses": []
+          }
+        }
+      ],
+      "session_input": {
+        "app_name": "malware_triage_agent",
+        "user_id": "test_user",
+        "state": {}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added `evals/malware_triage_eval.evalset.json` which defines a test case for the Malware Triage runbook.
Added `evals/README.md` with instructions on how to install dependencies and run the evaluation using `adk eval`.
This enables automated testing of the malware triage agent workflow.


---
*PR created automatically by Jules for task [7781049923427669312](https://jules.google.com/task/7781049923427669312) started by @dandye*