### PR TITLE
docs: Add Incident Handler's Handbook to documentation_links.md

### DIFF
--- a/rules_bank/documentation_links.md
+++ b/rules_bank/documentation_links.md
@@ -57,6 +57,7 @@ This document provides a centralized collection of external documentation refere
 - **SANS Incident Response Process**: https://www.sans.org/white-papers/incident-response-process/
 - **NIST Computer Security Incident Handling Guide**: https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final
 - **Carnegie Mellon Incident Response**: https://resources.sei.cmu.edu/library/asset-view.cfm?assetid=7029
+- **Incident Handler's Handbook (Patrick Kral)**: https://www.sans.org/white-papers/33901
 
 ### Playbooks & Procedures
 - **SOCFortress Playbooks**: https://github.com/socfortress/Playbooks

--- a/rules_bank/documentation_links.md
+++ b/rules_bank/documentation_links.md
@@ -57,7 +57,7 @@ This document provides a centralized collection of external documentation refere
 - **SANS Incident Response Process**: https://www.sans.org/white-papers/incident-response-process/
 - **NIST Computer Security Incident Handling Guide**: https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final
 - **Carnegie Mellon Incident Response**: https://resources.sei.cmu.edu/library/asset-view.cfm?assetid=7029
-- **Incident Handler's Handbook (Patrick Kral)**: https://www.sans.org/white-papers/33901
+- **Incident Handler's Handbook**: https://www.sans.org/white-papers/33901
 
 ### Playbooks & Procedures
 - **SOCFortress Playbooks**: https://github.com/socfortress/Playbooks

--- a/rules_bank/documentation_links.md
+++ b/rules_bank/documentation_links.md
@@ -57,7 +57,7 @@ This document provides a centralized collection of external documentation refere
 - **SANS Incident Response Process**: https://www.sans.org/white-papers/incident-response-process/
 - **NIST Computer Security Incident Handling Guide**: https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final
 - **Carnegie Mellon Incident Response**: https://resources.sei.cmu.edu/library/asset-view.cfm?assetid=7029
-- **Incident Handler's Handbook**: https://www.sans.org/white-papers/33901
+- **SANS Incident Handler's Handbook**: https://www.sans.org/white-papers/33901
 
 ### Playbooks & Procedures
 - **SOCFortress Playbooks**: https://github.com/socfortress/Playbooks


### PR DESCRIPTION
Added a new resource link to the "Incident Response" -> "PICERL Methodology" section in `rules_bank/documentation_links.md` as requested in the issue.

---
*PR created automatically by Jules for task [3924301821815825549](https://jules.google.com/task/3924301821815825549) started by @dandye*